### PR TITLE
Use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "node-uuid": "^1.4.7",
+    "prop-types": "^15.5.10",
     "ramda": "^0.22.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import uuid from "node-uuid"
-import React, {PropTypes} from "react"
+import React from "react"
+import PropTypes from "prop-types";
 import {renderSubtree} from "./render-subtree"
 import {componentRegistry as registerFactory} from "./component-registry"
 import {addDefaultContainer, unMountContainer, containerExists} from "./update-dom"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import uuid from "node-uuid"
 import React from "react"
-import PropTypes from "prop-types";
+import PropTypes from "prop-types"
 import {renderSubtree} from "./render-subtree"
 import {componentRegistry as registerFactory} from "./component-registry"
 import {addDefaultContainer, unMountContainer, containerExists} from "./update-dom"


### PR DESCRIPTION
Related to https://github.com/jpgorman/react-append-to-body/issues/5

Since a React upgrade is not required to use the prop-types package - I felt that keeping this PR simple for now may be best until further vetting of a React-upgrade can be assessed. 