### PR TITLE
Grab specific modules from Ramda

### DIFF
--- a/demo/complex.js
+++ b/demo/complex.js
@@ -2,7 +2,12 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import {Modal} from "./modal"
-import {reject, append, map, addIndex, contains, __} from "ramda"
+import reject from "ramda/src/reject"
+import append from "ramda/src/append"
+import map from "ramda/src/map"
+import addIndex from "ramda/src/addIndex"
+import contains from "ramda/src/contains"
+import __ from "ramda/src/__"
 
 import {
   componentWillAppendToBody

--- a/src/render-subtree.js
+++ b/src/render-subtree.js
@@ -1,7 +1,15 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import {containerExists} from "./update-dom"
-import {reduce, map, prop, propEq, compose, filter, partial, keys, uniq} from "ramda"
+import reduce from "ramda/src/reduce"
+import map from "ramda/src/map"
+import prop from "ramda/src/prop"
+import propEq from "ramda/src/propEq"
+import compose from "ramda/src/compose"
+import filter from "ramda/src/filter"
+import partial from "ramda/src/partial"
+import keys from "ramda/src/keys"
+import uniq from "ramda/src/uniq"
 
 function covertToArray(registry) {
   return reduce((accum, key) => {


### PR DESCRIPTION
It looks like Ramda doesn’t actually expose each module how we’d typically expect https://github.com/ramda/ramda/issues/2161#issuecomment-301450577 so this PR will more directly grab the specific pieces we need for a smaller package size.

Related https://github.com/jpgorman/react-append-to-body/issues/3

Before:
<img width="627" alt="screen shot 2017-06-28 at 10 29 06 am" src="https://user-images.githubusercontent.com/1018402/27642396-b19b96fe-5bec-11e7-8ff0-f5f635e09d9b.png">

After:

<img width="771" alt="screen shot 2017-06-28 at 10 29 22 am" src="https://user-images.githubusercontent.com/1018402/27642405-b5d3278c-5bec-11e7-9886-90db9cbf2925.png">