### PR TITLE
Feat: Remove use of componentWillMount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,15 +40,15 @@ export function componentWillAppendToBody(Component) {
     constructor(props, context) {
       super(props)
       this.ContextProvider = createContextProvider(context)
+
       if (props.subtreeContainer === "#subtree-container") {
         addDefaultContainer()
       }
-    }
 
-    componentWillMount() {
       this.uniqueId = uuidv4()
       !ReactDOM.createPortal && this.update()
     }
+
 
     componentDidUpdate() {
       !ReactDOM.createPortal && this.update()


### PR DESCRIPTION
In line with react 16.3.x warnings, moved the methods
calls in componenWillMount to the constructor. Fixes #16.